### PR TITLE
[ADD] extension.ts: Add extension.ts file which converts and json to grphqL schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+	"name": "jsontographqlschema",
+	"displayName": "jsonToGraphqlSchema",
+	"description": "",
+	"version": "0.0.1",
+	"engines": {
+		"vscode": "^1.37.1"
+	},
+	"categories": [
+		"Other"
+	],
+	"activationEvents": [
+		"onCommand:extension.convertToSchema"
+	],
+	"main": "./out/extension",
+	"contributes": {
+		"commands": [
+			{
+				"command": "extension.convertToSchema",
+				"title": "Convert JSON to GraohQL Schema"
+			}		
+		]
+	},
+	"scripts": {
+		"vscode:prepublish": "npm run compile",
+		"compile": "tsc -p ./",
+		"watch": "tsc -watch -p ./",
+		"pretest": "npm run compile",
+		"test": "node ./out/test/runTest.js"
+	},
+	"devDependencies": {
+		"@types/glob": "^7.1.1",
+		"@types/mocha": "^5.2.6",
+		"@types/node": "^10.12.21",
+		"@types/vscode": "^1.38.0",
+		"@walmartlabs/json-to-simple-graphql-schema": "^2.0.0",
+		"glob": "^7.1.4",
+		"mocha": "^6.1.4",
+		"tslint": "^5.12.1",
+		"typescript": "^3.3.1",
+		"vscode-test": "^1.2.0"
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,45 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+import * as vscode from 'vscode';
+import { jsonToSchema } from "@walmartlabs/json-to-simple-graphql-schema/lib";
+var path = require("path");
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+export function activate(context: vscode.ExtensionContext) {
+
+	// Use the console to output diagnostic information (console.log) and errors (console.error)
+	// This line of code will only be executed once when your extension is activated
+	console.log('Congratulations, your extension "jsontographqlschema" is now active!');
+
+	// The command has been defined in the package.json file
+	// Now provide the implementation of the command with registerCommand
+	// The commandId parameter must match the command field in package.json
+	let disposable = vscode.commands.registerCommand('extension.convertToSchema', () => {
+		// The code you place here will be executed every time your command is executed
+
+		// TODO: execute this command using some shortcut key
+		// Get the current file data
+		const data = vscode.window.activeTextEditor && vscode.window.activeTextEditor.document.getText();
+		// convert data into graphql schema
+		var schema = jsonToSchema({jsonInput: data});
+		// if any error occoured show error
+		if (schema.error) {
+			vscode.window.showErrorMessage(schema.error.message);			
+		}
+		if(schema.value) {
+			const content: vscode.TextDocument = schema.value;
+			vscode.window.showTextDocument(content).then((t: vscode.TextEditor) => {
+				let selection = t.selection;
+				t.edit(editBuilder => {
+					editBuilder.replace(selection, content.toString());
+				});
+			});
+		}
+	});
+
+	context.subscriptions.push(disposable);
+}
+
+// this method is called when your extension is deactivated
+export function deactivate() {}

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,0 +1,23 @@
+import * as path from 'path';
+
+import { runTests } from 'vscode-test';
+
+async function main() {
+	try {
+		// The folder containing the Extension Manifest package.json
+		// Passed to `--extensionDevelopmentPath`
+		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+
+		// The path to test runner
+		// Passed to --extensionTestsPath
+		const extensionTestsPath = path.resolve(__dirname, './suite/index');
+
+		// Download VS Code, unzip it and run the integration test
+		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+	} catch (err) {
+		console.error('Failed to run tests');
+		process.exit(1);
+	}
+}
+
+main();

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,0 +1,15 @@
+import * as assert from 'assert';
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from 'vscode';
+// import * as myExtension from '../extension';
+
+suite('Extension Test Suite', () => {
+	vscode.window.showInformationMessage('Start all tests.');
+
+	test('Sample test', () => {
+		assert.equal(-1, [1, 2, 3].indexOf(5));
+		assert.equal(-1, [1, 2, 3].indexOf(0));
+	});
+});

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,0 +1,37 @@
+import * as path from 'path';
+import * as Mocha from 'mocha';
+import * as glob from 'glob';
+
+export function run(): Promise<void> {
+	// Create the mocha test
+	const mocha = new Mocha({
+		ui: 'tdd',
+	});
+	mocha.useColors(true);
+
+	const testsRoot = path.resolve(__dirname, '..');
+
+	return new Promise((c, e) => {
+		glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+			if (err) {
+				return e(err);
+			}
+
+			// Add files to the test suite
+			files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+
+			try {
+				// Run the mocha test
+				mocha.run(failures => {
+					if (failures > 0) {
+						e(new Error(`${failures} tests failed.`));
+					} else {
+						c();
+					}
+				});
+			} catch (err) {
+				e(err);
+			}
+		});
+	});
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "es6",
+		"outDir": "out",
+		"lib": [
+			"es6"
+		],
+		"sourceMap": true,
+		"rootDir": "src",
+		"strict": true   /* enable all strict type-checking options */
+		/* Additional Checks */
+		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+	},
+	"exclude": [
+		"node_modules",
+		".vscode-test"
+	]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,15 @@
+{
+	"rules": {
+		"no-string-throw": true,
+		"no-unused-expression": true,
+		"no-duplicate-variable": true,
+		"curly": true,
+		"class-name": true,
+		"semicolon": [
+			true,
+			"always"
+		],
+		"triple-equals": true
+	},
+	"defaultSeverity": "warning"
+}


### PR DESCRIPTION
# How to run and test?

1. Clone this repo
2. After cloning go inside folder `json-to-graphql-schema`  Checkout to this branch `add-business-logic` (As the whole implementation is in this branch)
3. Do `npm install`
4. Now open vs code and then, inside the editor, press F5. This will compile and run the extension in a new Extension Development Host window.
5. Now add any sinple JSON which you want to convert to GraphQl schema into file.
6. Run the `Convert JSON to GraohQL Schema` command from the Command Palette (⇧⌘P) or `shift+cmd+c` on mac or `ctrl+alt+c` on other devices which will open converted GraphQl schema into new file.

# Description

- We are using 'https://github.com/walmartlabs/json-to-simple-graphql-schema.git' library to convert JSON to GraphQL schema.
- Used 'jsonToSchema' function which accepts object {jsonInput: data: String} and returns converted string in object {value: convertedString: String} and if there are any errors in conversion then it will return {error: errorMessage: String}.
- If there is any error then show the returned error message.
- If JSON converted successfully then create a new untitled file using 'showTextDocument'.
- After that in then, it will give 'TextEditorEdit' object and using it's 'edit' method add converted schema text into an untitled file